### PR TITLE
Adds an addittional argument to allow for provision of index to harpoon

### DIFF
--- a/lua/harpoon/mark.lua
+++ b/lua/harpoon/mark.lua
@@ -200,7 +200,7 @@ M.valid_index = function(idx)
     return file_name ~= nil and file_name ~= ""
 end
 
-M.add_file = function(file_name_or_buf_id)
+M.add_file = function(file_name_or_buf_id, mark_position_override)
     filter_filetype()
     local buf_name = get_buf_name(file_name_or_buf_id)
     log.trace("add_file():", buf_name)
@@ -212,8 +212,14 @@ M.add_file = function(file_name_or_buf_id)
 
     validate_buf_name(buf_name)
 
-    local found_idx = get_first_empty_slot()
-    harpoon.get_mark_config().marks[found_idx] = create_mark(buf_name)
+    local mark_index = 0
+    if mark_position_override then
+        mark_index = mark_position_override
+    else
+        mark_index = get_first_empty_slot()
+    end
+
+    harpoon.get_mark_config().marks[mark_index] = create_mark(buf_name)
     M.remove_empty_tail(false)
     emit_changed()
 end


### PR DESCRIPTION
## Description

Adds additional logic to the process of adding new buffers to the harpoon list to allow for provision of harpoon list index to the `harpoon.mark.add_file()` function as the second argument. Preserving existing functionality is prioritized so the API functionality contract was preserved.

## Usage

#### Regular `add_file()` that appends to the end of the list

```vim
:lua require("harpoon.mark").add_file()
```

#### New non-breaking syntax to provide a specific index to `add_file()`

Set the current buffer as the 1st harpoon item:  
 
```vim
:lua require("harpoon.mark").add_file(nil, 1)
```

Set the current buffer as the 2nd harpoon item:  
 
```vim
:lua require("harpoon.mark").add_file(nil, 2)
```

Set the current buffer as the 3rd harpoon item:  
 
```vim
:lua require("harpoon.mark").add_file(nil, 3)
```

Set the current buffer as the 4th harpoon item:  
 
```vim
:lua require("harpoon.mark").add_file(nil, 4)
```