### PR TITLE
Adds alternative file overrides logic

### DIFF
--- a/lua/harpoon/mark.lua
+++ b/lua/harpoon/mark.lua
@@ -205,9 +205,19 @@ M.add_file = function(file_name_or_buf_id, mark_position_override)
     local buf_name = get_buf_name(file_name_or_buf_id)
     log.trace("add_file():", buf_name)
 
+    -- if file already in the list
     if M.valid_index(M.get_index_of(buf_name)) then
-        -- we don't alter file layout.
-        return
+        if mark_position_override then
+            -- to avoid having the same file
+            -- in the list more than 1 time
+            -- first remove the file from the list
+            M.rm_file(buf_name)
+            -- then it will be added back to the list
+            -- but with the new index
+        else
+            -- we don't alter file layout.
+            return
+        end
     end
 
     validate_buf_name(buf_name)


### PR DESCRIPTION
## Description

Adds alternative file overrides logic to implement a new reliable alternative to the mapping logic.

The final goal is to never have to open the harpoon list to manage or adjust the index/presence of a certain file.

## Usage

This logic works as follows:


Imagine the following harpoon list

```
1  utils/index.js
2  docs/README.md
3  src/App.vue
4  ____________
```

The user opens `docs/README.md` and immediately decides to assign that file to index 3 in the list. They press a specific remap that calls `:lua require("harpoon.mark").add_file(nil, 3)<CR>` and that transforms the list to the following

```
1  utils/index.js
2  (empty)
3  docs/README.md
4  ____________
```

This way the user is always in direct control of assigning any buffer to a specific position (index) in the list with just one remap. No menus, no popups, no GUI. Just pure reliable control and quick interaction.